### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,10 +6,12 @@ on:
 permissions: {}
 jobs:
   release:
-    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@b2ecf54e35aca9e9689e761f5bd6d1ad9542a8cf # v8.0.0
+    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0
     with:
       go-version-file: go.mod
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -1,12 +1,18 @@
 ---
 name: wc-test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 
 jobs:
   test:
     timeout-minutes: 30
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -14,6 +20,11 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
           aqua_version: v2.59.1

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,17 +1,28 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   integration-test:
     uses: ./.github/workflows/wc-test.yaml
-    permissions: {}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+    permissions:
+      contents: read
+      id-token: write
 
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
       golangci-lint-timeout: 120s
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write


### PR DESCRIPTION
Introduce takumi guard (the Go variant) into the CI workflows.

## Changes

- `.github/workflows/release.yaml`:
  - Bump `go-release-workflow` from `v8.0.0` to `v8.1.0`.
  - Add a `secrets:` block passing `TAKUMI_GUARD_BOT_ID` to the `release` job.

- `.github/workflows/workflow_call_test.yaml`:
  - Declare the `TAKUMI_GUARD_BOT_ID` secret (`required: true`) under `on.workflow_call`.
  - Bump `go-test-full-workflow` from `v5.0.2` to `v6.0.0`.
  - Pass `TAKUMI_GUARD_BOT_ID` to the `test` (go-test-full-workflow) job and add `id-token: write` to its permissions.
  - Pass `TAKUMI_GUARD_BOT_ID` to the local `integration-test` (`wc-test.yaml`) job and add `contents: read` + `id-token: write` permissions.

- `.github/workflows/wc-test.yaml`:
  - Declare the `TAKUMI_GUARD_BOT_ID` secret (`required: true`) under `on.workflow_call`.
  - Add the `flatt-security/setup-takumi-guard-golang@v1` setup step immediately after `actions/setup-go` and before `aqua-installer` / `go run`.
  - Replace `permissions: {}` with `contents: read` + `id-token: write` on the `test` job.

- `.github/workflows/test.yaml`:
  - Pass `TAKUMI_GUARD_BOT_ID` to the local `test` (`workflow_call_test.yaml`) job and add `id-token: write` to its permissions, propagating the secret from the `pull_request` entrypoint down the reusable-workflow chain.

## Note

The `go-test-full-workflow` reusable workflow was bumped across a MAJOR version (`v5.0.2` -> `v6.0.0`). Please review CI for potential breaking changes.

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)